### PR TITLE
Remove hard lock to python 3.7

### DIFF
--- a/scripts/Pipfile
+++ b/scripts/Pipfile
@@ -16,4 +16,4 @@ hu_build = {version="*", index="hu_pypi"}
 [dev-packages]
 
 [requires]
-python_version = "3.7"
+


### PR DESCRIPTION
We'll have to get pyenv on the build agents.